### PR TITLE
SteveDMurphy-log-based-ct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # config
 config.json
+catalog.json

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "attrs==16.3.0",
         "pendulum==1.2.0",
         "singer-python==5.9.0",
-        "sqlalchemy==1.3.6",
+        "sqlalchemy<2.0.0",
         "pyodbc==4.0.26",
         "backoff==1.8.0",
     ],

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -557,19 +557,9 @@ def do_sync_log_based_table(mssql_conn, config, catalog_entry, state, columns):
             log_based.current_log_version,
         )
 
-        # log_based.state = state
     else:
         LOGGER.info("Continue log-based syncing")
         log_based.execute_log_based_sync()
-        LOGGER.warn(log_based.current_log_version)
-        # state = singer.write_bookmark(
-        #     state,
-        #     catalog_entry.tap_stream_id,
-        #     "current_log_version",
-        #     log_based.current_log_version,
-        # )
-
-    # singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
 
 def sync_non_binlog_streams(mssql_conn, non_binlog_catalog, config, state):

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -510,59 +510,64 @@ def do_sync_full_table(mssql_conn, config, catalog_entry, state, columns):
 
 def do_sync_log_based_table(mssql_conn, config, catalog_entry, state, columns):
 
-    ## incremental
-    # md_map = metadata.to_map(catalog_entry.metadata)
-    # stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
-    # replication_key = md_map.get((), {}).get("replication-key")
-    # write_schema_message(
-    #     catalog_entry=catalog_entry, bookmark_properties=[replication_key]
-    # )
-    # LOGGER.info("Schema written")
-    # incremental.sync_table(mssql_conn, config, catalog_entry, state, columns)
-
-    # singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
-
-    ## full_table
     key_properties = common.get_key_properties(catalog_entry)
 
     write_schema_message(catalog_entry)
 
     stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
 
-    log_based = logical.log_based_sync(mssql_conn, config, catalog_entry, state, columns)
-    LOGGER.info("Slartibartfast")
-    # attrs = vars(log_based)
-    # {'kids': 0, 'name': 'Dog', 'color': 'Spotted', 'age': 10, 'legs': 2, 'smell': 'Alot'}
-    # now dump this in some way or another
-    # LOGGER.info(', '.join("%s: %s" % item for item in attrs.items()))
+    # initial instance of log_based connector class
+    log_based = logical.log_based_sync(
+        mssql_conn, config, catalog_entry, state, columns
+    )
 
+    # assert all of the log_based prereq's are met
     log_based.assert_log_based_is_enabled()
-    # full_table.sync_table(
-    #     mssql_conn, config, catalog_entry, state, columns, stream_version
-    # )
 
     # create state if none exists
-    log_based.log_based_init_state()
+    initial_full_table_complete = log_based.log_based_init_state()
+
+    if not initial_full_table_complete:
+        state = singer.write_bookmark(
+            state,
+            catalog_entry.tap_stream_id,
+            "initial_full_table_complete",
+            log_based.initial_full_table_complete,
+        )
+        state = singer.write_bookmark(
+            state,
+            catalog_entry.tap_stream_id,
+            "current_log_version",
+            log_based.current_log_version,
+        )
+
+        log_based.state = state
 
     initial_load = log_based.log_based_initial_full_table()
 
     if initial_load:
-        LOGGER.info("do full sync")
-        LOGGER.info("update state")
+        do_sync_full_table(mssql_conn, config, catalog_entry, state, columns)
+        state = singer.write_bookmark(
+            state, catalog_entry.tap_stream_id, "initial_full_table_complete", True
+        )
+        state = singer.write_bookmark(
+            state,
+            catalog_entry.tap_stream_id,
+            "current_log_version",
+            log_based.current_log_version,
+        )
+
+        # log_based.state = state
     else:
         LOGGER.info("Continue log-based syncing")
-
-    # if state is not good
-    ## do a full sync and write state
-    # else
-    ## do a logbased sync
-
-    # Prefer initial_full_table_complete going forward
-    # singer.clear_bookmark(state, catalog_entry.tap_stream_id, "version")
-
-    # state = singer.write_bookmark(
-    #     state, catalog_entry.tap_stream_id, "initial_full_table_complete", True
-    # )
+        log_based.execute_log_based_sync()
+        LOGGER.warn(log_based.current_log_version)
+        # state = singer.write_bookmark(
+        #     state,
+        #     catalog_entry.tap_stream_id,
+        #     "current_log_version",
+        #     log_based.current_log_version,
+        # )
 
     # singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
@@ -614,8 +619,12 @@ def sync_non_binlog_streams(mssql_conn, non_binlog_catalog, config, state):
                 LOGGER.info(f"syncing {catalog_entry.table} full table")
                 do_sync_full_table(mssql_conn, config, catalog_entry, state, columns)
             elif replication_method == "LOG_BASED":
-                LOGGER.info(f"syncing {catalog_entry.table} using replication method LOG_BASED")
-                do_sync_log_based_table(mssql_conn, config, catalog_entry, state, columns)
+                LOGGER.info(
+                    f"syncing {catalog_entry.table} using replication method LOG_BASED"
+                )
+                do_sync_log_based_table(
+                    mssql_conn, config, catalog_entry, state, columns
+                )
             else:
                 raise Exception(
                     "only INCREMENTAL and FULL TABLE replication methods are supported"

--- a/tap_mssql/connection.py
+++ b/tap_mssql/connection.py
@@ -10,6 +10,8 @@ from sqlalchemy.engine import Engine
 import singer
 import ssl
 
+from urllib.parse import quote_plus
+
 LOGGER = singer.get_logger()
 
 
@@ -36,7 +38,7 @@ def get_azure_sql_engine(config) -> Engine:
     conn_values = {
         "prefix": "mssql+pyodbc://",
         "username": config["user"],
-        "password": config["password"],
+        "password": quote_plus(config["password"]),
         "port": config.get("port", "1433"),
         "host": config["host"],
         "driver": "ODBC+Driver+17+for+SQL+Server",

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -20,10 +20,6 @@ BOOKMARK_KEYS = {
     "initial_full_table_complete",
 }
 
-# do_sync_incremental(mssql_conn, config, catalog_entry, state, columns)
-
-# do_sync_full_table(mssql_conn, config, catalog_entry, state, columns)
-
 
 class log_based_sync:
     """
@@ -340,12 +336,3 @@ class log_based_sync:
             single_result = row[column]
 
         return single_result
-
-
-# def sync_table(mssql_conn, config, catalog_entry, state, columns):
-#     mssql_conn = MSSQLConnection(config)
-#     common.whitelist_bookmark_keys(
-#         generate_bookmark_keys(catalog_entry), catalog_entry.tap_stream_id, state
-#     )
-
-# 24000870

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# pylint: disable=duplicate-code
+
+import pendulum
+import singer
+from singer import metadata
+
+from tap_mssql.connection import (
+    connect_with_backoff,
+    get_azure_sql_engine,
+)
+import tap_mssql.sync_strategies.common as common
+
+LOGGER = singer.get_logger()
+
+BOOKMARK_KEYS = {
+    "current_log_version",
+    "last_pk_fetched",
+    "initial_full_table_complete",
+}
+
+# do_sync_incremental(mssql_conn, config, catalog_entry, state, columns)
+
+# do_sync_full_table(mssql_conn, config, catalog_entry, state, columns)
+
+
+class log_based_sync:
+    """
+    Methods to validate the log-based sync of a table from mssql
+    """
+
+    def __init(self, mssql_conn, config, catalog_entry, state, columns):
+        self.logger = singer.get_logger()
+        self.config = config
+        self.catalog_entry = catalog_entry
+        self.state = state
+        self.columns = columns
+        self.database_name = common.get_database_name(
+            self.catalog_entry
+        )  # this is actually the schema name, database should be supplied elsewhere as required (config appears to be used today)
+        self.table_name = catalog_entry.table
+        self.mssql_conn = get_azure_sql_engine(config)
+
+    def assert_log_based_is_enabled(self):
+
+        database_is_change_tracking_enabled = _get_change_tracking_database()
+
+        table_is_change_tracking_enabled = _get_change_tracking_tables()
+
+        min_valid_version = _get_min_valid_version()
+
+        if (
+            database_is_change_tracking_enabled
+            & table_is_change_tracking_enabled
+            & min_valid_version
+        ):
+            return True
+        else:
+            return False
+
+    def _get_change_tracking_database(
+        self,
+    ):  # do this the first time only as required? future change for now
+        self.logger.info("Validate the database for change tracking")
+
+        database_id = (
+            self.database_name
+        )  # TODO: this should actually come from the config instead to validate. Alternatively, it may just work if is not null
+
+        sql_query = (
+            "SELECT DB_NAME(database_id) AS db_name FROM sys.change_tracking_databases"
+        )
+
+        database_is_change_tracking_enabled = False
+
+        with self.mssql_conn.connect() as open_conn:
+            results = open_conn.execute(sql_query)
+            row = results.fetchone()
+
+            if row["db_name"] == database_id:
+                database_is_change_tracking_enabled = True
+
+        return database_is_change_tracking_enabled
+
+    def _get_change_tracking_tables(self):  # do this the first time only as required?
+
+        self.logger.info("Validating the schemas and tables for change tracking")
+
+        schema_table = (self.database_name, self.table_name)
+
+        sql_query = """
+            SELECT OBJECT_SCHEMA_NAME(object_id) AS schema_name,
+            OBJECT_NAME(object_id) AS table_name
+            FROM sys.change_tracking_tables
+            """
+
+        table_is_change_tracking_enabled = False
+        with self.mssql_conn.connect() as open_conn:
+            change_tracking_tables = open_conn.execute(sql_query)
+
+            if schema_table in change_tracking_tables.fetchall():
+                table_is_change_tracking_enabled = True
+
+        return table_is_change_tracking_enabled  # this should be the table name
+
+    def _get_min_valid_version(self):  # should be per table I think?
+
+        self.logger.info("Validating the min_valid_version")
+
+        sql_query = "SELECT CHANGE_TRACKING_MIN_VALID_VERSION({}) as min_valid_version"
+        object_id = _get_object_version_by_table_name()
+
+        with self.mssql_conn.connect() as open_conn:
+            results = open_conn.execute(sql_query.format(object_id))
+            row = results.fetchone()
+
+            min_valid_version = row["min_valid_version"]
+
+        return min_valid_version  # return a valid version
+
+    def _get_object_version_by_table_name(self):  # should be per table I think?
+
+        self.logger.info("Getting object_id by name")
+
+        schema_table = self.database_name + "." + self.table_name
+        # config.database_name
+        # sel
+        sql_query = "SELECT OBJECT_ID({}) AS object_id"
+        #    (-> (partial format "%s.%s.%s")
+        with self.mssql_conn.connect() as open_conn:
+            results = open_conn.execute(sql_query.format(schema_table))
+            row = results.fetchone()
+
+            object_id = row["object_id"]
+
+        return object_id
+
+    def log_based_init_state(self):
+        # this appears to look for an existing state and gets the current log version if necessary
+        # also setting the initial_full_table_complete state to false
+        initial_full_table_complete = (
+            None  # need to pull this from a bookmark/state area
+        )
+        if initial_full_table_complete is None:
+            current_log_version = _get_current_log_version()
+            print(
+                "set the current_log_version to the received version and set initial_full_table_complete to False"
+            )
+            print("write state for stream-name to stdout")
+
+    def _get_current_log_version(self):
+
+        sql_query = "SELECT current_version = CHANGE_TRACKING_CURRENT_VERSION()"
+
+        current_log_version = _get_single_result(sql_query, "current_version")
+
+        return current_log_version
+
+    def log_based_initial_full_table(self):
+        "Determine if we should run a full load of the table or use state."
+        return True
+
+    def log_based_sync(self):
+        "Confirm we have state and run a log based query. This will be larger."
+        return True
+
+    def _get_single_result(self, sql_query, column):
+        """
+        This method takes a query and column name parameter
+        and fetches then returns the single result as required.
+        """
+        with self.mssql_conn.connect() as open_conn:
+            results = open_conn.execute(sql_query)
+            row = results.fetchone()
+
+            single_result = row[column]
+
+        return single_result
+
+
+# def sync_table(mssql_conn, config, catalog_entry, state, columns):
+#     mssql_conn = MSSQLConnection(config)
+#     common.whitelist_bookmark_keys(
+#         generate_bookmark_keys(catalog_entry), catalog_entry.tap_stream_id, state
+#     )

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -203,7 +203,7 @@ class log_based_sync:
 
         key_properties = common.get_key_properties(self.catalog_entry)
         ct_sql_query = self._build_ct_sql_query(key_properties)
-        self.logger.info("Executing query: {}".format(ct_sql_query))
+        self.logger.info("Executing log-based query: {}".format(ct_sql_query))
         time_extracted = utils.now()
         stream_version = common.get_stream_version(
             self.catalog_entry.tap_stream_id, self.state


### PR DESCRIPTION
Log-based replication for change tracking, using [singer-io/tap-mssql](https://github.com/singer-io/tap-mssql/blob/master/src/tap_mssql/sync_strategies/logical.clj) as a reference.

This PR should implement a minimum viable production for [MSSQL Change Tracking](https://docs.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-tracking-sql-server?view=sql-server-ver15)

Took a stab at using a class, thinking it might reduce some repetition down the road but open to walking that back for sure