### PR TITLE
Update current_log_version on full sync

### DIFF
--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -551,6 +551,8 @@ def do_sync_log_based_table(mssql_conn, config, catalog_entry, state, columns):
         state = singer.write_bookmark(
             state, catalog_entry.tap_stream_id, "initial_full_table_complete", True
         )
+
+        self.logger.info("****Should update right here!!! " + str(log_based.current_log_version))        
         state = singer.write_bookmark(
             state,
             catalog_entry.tap_stream_id,

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -535,8 +535,6 @@ def do_sync_log_based_table(mssql_conn, config, catalog_entry, state, columns):
             "initial_full_table_complete",
             log_based.initial_full_table_complete,
         )
-        LOGGER.info("****if not initial_full_table_complete.  current log version is: " + str(log_based.current_log_version)) 
-        #LOGGER.info(log_based.current_log_version)  
         state = singer.write_bookmark(
             state,
             catalog_entry.tap_stream_id,
@@ -554,8 +552,6 @@ def do_sync_log_based_table(mssql_conn, config, catalog_entry, state, columns):
             state, catalog_entry.tap_stream_id, "initial_full_table_complete", True
         )
 
-        LOGGER.info("****if initial_load: current log version is: " + str(log_based.current_log_version)) 
-        #LOGGER.info(log_based.current_log_version)    
         state = singer.write_bookmark(
             state,
             catalog_entry.tap_stream_id,

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -552,7 +552,8 @@ def do_sync_log_based_table(mssql_conn, config, catalog_entry, state, columns):
             state, catalog_entry.tap_stream_id, "initial_full_table_complete", True
         )
 
-        self.logger.info("****Should update right here!!! " + str(log_based.current_log_version))        
+        self.logger.info("****Should update right here!!!")   
+        self.logger.info(log_based.current_log_version)        
         state = singer.write_bookmark(
             state,
             catalog_entry.tap_stream_id,

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -535,6 +535,8 @@ def do_sync_log_based_table(mssql_conn, config, catalog_entry, state, columns):
             "initial_full_table_complete",
             log_based.initial_full_table_complete,
         )
+        LOGGER.info("****if not initial_full_table_complete") 
+        LOGGER.info(log_based.current_log_version)  
         state = singer.write_bookmark(
             state,
             catalog_entry.tap_stream_id,
@@ -552,8 +554,8 @@ def do_sync_log_based_table(mssql_conn, config, catalog_entry, state, columns):
             state, catalog_entry.tap_stream_id, "initial_full_table_complete", True
         )
 
-        self.logger.info("****Should update right here!!!")   
-        self.logger.info(log_based.current_log_version)        
+        LOGGER.info("****if initial_load: Should update right here!!!") 
+        LOGGER.info(log_based.current_log_version)    
         state = singer.write_bookmark(
             state,
             catalog_entry.tap_stream_id,

--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -535,8 +535,8 @@ def do_sync_log_based_table(mssql_conn, config, catalog_entry, state, columns):
             "initial_full_table_complete",
             log_based.initial_full_table_complete,
         )
-        LOGGER.info("****if not initial_full_table_complete") 
-        LOGGER.info(log_based.current_log_version)  
+        LOGGER.info("****if not initial_full_table_complete.  current log version is: " + str(log_based.current_log_version)) 
+        #LOGGER.info(log_based.current_log_version)  
         state = singer.write_bookmark(
             state,
             catalog_entry.tap_stream_id,
@@ -554,8 +554,8 @@ def do_sync_log_based_table(mssql_conn, config, catalog_entry, state, columns):
             state, catalog_entry.tap_stream_id, "initial_full_table_complete", True
         )
 
-        LOGGER.info("****if initial_load: Should update right here!!!") 
-        LOGGER.info(log_based.current_log_version)    
+        LOGGER.info("****if initial_load: current log version is: " + str(log_based.current_log_version)) 
+        #LOGGER.info(log_based.current_log_version)    
         state = singer.write_bookmark(
             state,
             catalog_entry.tap_stream_id,

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -179,22 +179,19 @@ class log_based_sync:
         "Determine if we should run a full load of the table or use state."
 
         min_valid_version = self._get_min_valid_version()
-        self.logger.info('***Before the new pull: ' + str(self.current_log_version))
-        self.current_log_version = self._get_current_log_version()
-        self.logger.info('***min_valid_version:' + str(min_valid_version))
-        self.logger.info('***Current_log_version:' + str(self.current_log_version))
-        if self.current_log_version is None: # prevents the operator in the else statement from erroring if None 
-            min_version_out_of_date = False
-            self.current_log_version = current_log_version
-        else: 
-            min_version_out_of_date = min_valid_version > self.current_log_version
 
-        if self.initial_full_table_complete == False:
+        min_version_out_of_date = min_valid_version > self.current_log_version
+        
+        if self.current_log_version is None and self.initial_full_table_complete == True:
+            self.logger.info("Conflicting state.  Initial_full_table_complete = true with current_log_version = null")
+            return True
+
+        elif self.initial_full_table_complete == False:
             self.logger.info("No initial load found, executing a full table sync.")
             return True
 
         elif (
-            self.initial_full_table_complete == True and min_version_out_of_date == True 
+            self.initial_full_table_complete == True and min_version_out_of_date == True
         ):
             self.logger.info(
                 "CHANGE_TRACKING_MIN_VALID_VERSION has reported a value greater than current-log-version. Executing a full table sync."

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -181,10 +181,11 @@ class log_based_sync:
         min_valid_version = self._get_min_valid_version()
 
         if self.current_log_version is None and self.initial_full_table_complete == True: # prevents the operator in the else statement from erroring if None 
+            self.current_log_version = self._get_current_log_version()
             self.logger.info("Conflicting state.  Initial_full_table_complete = true with current_log_version = null")
             return True
         else:
-            
+
             min_version_out_of_date = min_valid_version > self.current_log_version
 
             if self.initial_full_table_complete == False:

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -179,7 +179,7 @@ class log_based_sync:
 
         min_valid_version = self._get_min_valid_version()
 
-        if self.current_log_version is None:
+        if self.current_log_version is None: # prevents the operator in the else statement from erroring if None 
             min_version_out_of_date = False
             self.current_log_version = min_valid_version
         else: 

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -184,7 +184,7 @@ class log_based_sync:
         self.logger.info('***Current_log_version:' + str(self.current_log_version))
         if self.current_log_version is None: # prevents the operator in the else statement from erroring if None 
             min_version_out_of_date = False
-            self.current_log_version = self._get_current_log_version()
+            self.current_log_version = current_log_version
         else: 
             min_version_out_of_date = min_valid_version > self.current_log_version
 

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -172,7 +172,6 @@ class log_based_sync:
 
         current_log_version = self._get_single_result(sql_query, "current_version")
         
-        self.logger.info("current_log_version!!!!!!!!!" + str(current_log_version))
         return current_log_version
 
     def log_based_initial_full_table(self):
@@ -335,11 +334,8 @@ class log_based_sync:
         """
         with self.mssql_conn.connect() as open_conn:
             results = open_conn.execute(sql_query)
-
-            self.logger.info("***results!!!!!!!!!" + str(results))
             row = results.fetchone()
 
-            self.logger.info("***row!!!!!!!!!" + str(row))
             single_result = row[column]
         
         return single_result

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -179,6 +179,7 @@ class log_based_sync:
         "Determine if we should run a full load of the table or use state."
 
         min_valid_version = self._get_min_valid_version()
+        self.logger.info('***Before the new pull: ' + str(self.current_log_version))
         self.current_log_version = self._get_current_log_version()
         self.logger.info('***min_valid_version:' + str(min_valid_version))
         self.logger.info('***Current_log_version:' + str(self.current_log_version))

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -171,7 +171,8 @@ class log_based_sync:
         sql_query = "SELECT current_version = CHANGE_TRACKING_CURRENT_VERSION()"
 
         current_log_version = self._get_single_result(sql_query, "current_version")
-
+        
+        self.logger.info("current_log_version!!!!!!!!!" + str(current_log_version))
         return current_log_version
 
     def log_based_initial_full_table(self):
@@ -339,8 +340,11 @@ class log_based_sync:
         """
         with self.mssql_conn.connect() as open_conn:
             results = open_conn.execute(sql_query)
+
+            self.logger.info("***results!!!!!!!!!" + str(results))
             row = results.fetchone()
 
+            self.logger.info("***row!!!!!!!!!" + str(results))
             single_result = row[column]
-
+        
         return single_result

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -180,19 +180,14 @@ class log_based_sync:
 
         min_valid_version = self._get_min_valid_version()
 
-        if self.current_log_version is None and self.initial_full_table_complete == True: # prevents the operator in the else statement from erroring if None 
+        if self.current_log_version is None: # prevents the operator in the else statement from erroring if None 
             self.current_log_version = self._get_current_log_version()
-            self.logger.info("Conflicting state.  Initial_full_table_complete = true with current_log_version = null")
+            self.logger.info("executing a full table sync.")
             return True
         else:
-
             min_version_out_of_date = min_valid_version > self.current_log_version
 
-            if self.initial_full_table_complete == False:
-                self.logger.info("No initial load found, executing a full table sync.")
-                return True
-
-            elif (
+            if (
                 self.initial_full_table_complete == True and min_version_out_of_date == True
             ):
                 self.logger.info(

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -181,7 +181,7 @@ class log_based_sync:
 
         if self.current_log_version is None: # prevents the operator in the else statement from erroring if None 
             min_version_out_of_date = False
-            self.current_log_version = min_valid_version
+            self.current_log_version = self._get_current_log_version()
         else: 
             min_version_out_of_date = min_valid_version > self.current_log_version
 

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -189,7 +189,7 @@ class log_based_sync:
             self.logger.info(
                 "CHANGE_TRACKING_MIN_VALID_VERSION has reported a value greater than current-log-version. Executing a full table sync."
             )
-            self.current_log_version = None
+            #self.current_log_version = None
             return True
         else:
             return False

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -180,8 +180,8 @@ class log_based_sync:
 
         min_valid_version = self._get_min_valid_version()
         self.current_log_version = self._get_current_log_version()
-        self.logger.info('min_valid_version' + str(min_valid_version))
-        self.logger.info('Current_log_version' + str(self.current_log_version))
+        self.logger.info('***min_valid_version:' + str(min_valid_version))
+        self.logger.info('***Current_log_version:' + str(self.current_log_version))
         if self.current_log_version is None: # prevents the operator in the else statement from erroring if None 
             min_version_out_of_date = False
             self.current_log_version = self._get_current_log_version()
@@ -344,7 +344,7 @@ class log_based_sync:
             self.logger.info("***results!!!!!!!!!" + str(results))
             row = results.fetchone()
 
-            self.logger.info("***row!!!!!!!!!" + str(results))
+            self.logger.info("***row!!!!!!!!!" + str(row))
             single_result = row[column]
         
         return single_result

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -181,7 +181,7 @@ class log_based_sync:
 
         min_version_out_of_date = min_valid_version > self.current_log_version
 
-        if self.initial_full_table_complete == False :
+        if self.initial_full_table_complete == False:
             self.logger.info("No initial load found, executing a full table sync.")
             return True
 
@@ -189,7 +189,7 @@ class log_based_sync:
             self.logger.info(
                 "CHANGE_TRACKING_MIN_VALID_VERSION has reported a value greater than current-log-version. Executing a full table sync."
             )
-            self.current_log_version = None 
+            self.current_log_version = None
             return True
         else:
             return False

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -178,7 +178,9 @@ class log_based_sync:
         "Determine if we should run a full load of the table or use state."
 
         min_valid_version = self._get_min_valid_version()
-
+        self.current_log_version = self._get_current_log_version()
+        self.logger.info('min_valid_version' + str(min_valid_version))
+        self.logger.info('Current_log_version' + str(self.current_log_version))
         if self.current_log_version is None: # prevents the operator in the else statement from erroring if None 
             min_version_out_of_date = False
             self.current_log_version = self._get_current_log_version()

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -185,7 +185,9 @@ class log_based_sync:
             self.logger.info("No initial load found, executing a full table sync.")
             return True
 
-        elif (self.initial_full_table_complete == True and min_version_out_of_date == True):
+        elif (
+            self.initial_full_table_complete == True and min_version_out_of_date == True
+        ):
             self.logger.info(
                 "CHANGE_TRACKING_MIN_VALID_VERSION has reported a value greater than current-log-version. Executing a full table sync."
             )

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -179,19 +179,21 @@ class log_based_sync:
 
         min_valid_version = self._get_min_valid_version()
 
-        min_version_out_of_date = min_valid_version > self.current_log_version
+        if self.current_log_version is None:
+            min_version_out_of_date = False
+        else: 
+            min_version_out_of_date = min_valid_version > self.current_log_version
 
         if self.initial_full_table_complete == False:
             self.logger.info("No initial load found, executing a full table sync.")
             return True
 
         elif (
-            self.initial_full_table_complete == True and min_version_out_of_date == True
+            self.initial_full_table_complete == True and min_version_out_of_date == True 
         ):
             self.logger.info(
                 "CHANGE_TRACKING_MIN_VALID_VERSION has reported a value greater than current-log-version. Executing a full table sync."
             )
-            self.current_log_version = None
             return True
         else:
             return False

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -186,6 +186,7 @@ class log_based_sync:
 
         if self.initial_full_table_complete == False:
             self.logger.info("No initial load found, executing a full table sync.")
+            self.current_log_version = min_valid_version
             return True
 
         elif (

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -180,25 +180,26 @@ class log_based_sync:
 
         min_valid_version = self._get_min_valid_version()
 
-        min_version_out_of_date = min_valid_version > self.current_log_version
-        
-        if self.current_log_version is None and self.initial_full_table_complete == True:
+        if self.current_log_version is None and self.initial_full_table_complete == True: # prevents the operator in the else statement from erroring if None 
             self.logger.info("Conflicting state.  Initial_full_table_complete = true with current_log_version = null")
             return True
-
-        elif self.initial_full_table_complete == False:
-            self.logger.info("No initial load found, executing a full table sync.")
-            return True
-
-        elif (
-            self.initial_full_table_complete == True and min_version_out_of_date == True
-        ):
-            self.logger.info(
-                "CHANGE_TRACKING_MIN_VALID_VERSION has reported a value greater than current-log-version. Executing a full table sync."
-            )
-            return True
         else:
-            return False
+            
+            min_version_out_of_date = min_valid_version > self.current_log_version
+
+            if self.initial_full_table_complete == False:
+                self.logger.info("No initial load found, executing a full table sync.")
+                return True
+
+            elif (
+                self.initial_full_table_complete == True and min_version_out_of_date == True
+            ):
+                self.logger.info(
+                    "CHANGE_TRACKING_MIN_VALID_VERSION has reported a value greater than current-log-version. Executing a full table sync."
+                )
+                return True
+            else:
+                return False
 
     def execute_log_based_sync(self):
         "Confirm we have state and run a log based query. This will be larger."

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -189,7 +189,7 @@ class log_based_sync:
             self.logger.info(
                 "CHANGE_TRACKING_MIN_VALID_VERSION has reported a value greater than current-log-version. Executing a full table sync."
             )
-            #self.current_log_version = None
+            self.current_log_version = None
             return True
         else:
             return False

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -181,12 +181,12 @@ class log_based_sync:
 
         if self.current_log_version is None:
             min_version_out_of_date = False
+            self.current_log_version = min_valid_version
         else: 
             min_version_out_of_date = min_valid_version > self.current_log_version
 
         if self.initial_full_table_complete == False:
             self.logger.info("No initial load found, executing a full table sync.")
-            self.current_log_version = min_valid_version
             return True
 
         elif (

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -181,16 +181,15 @@ class log_based_sync:
 
         min_version_out_of_date = min_valid_version > self.current_log_version
 
-        if self.initial_full_table_complete == False:
+        if self.initial_full_table_complete == False :
             self.logger.info("No initial load found, executing a full table sync.")
             return True
 
-        elif (
-            self.initial_full_table_complete == True and min_version_out_of_date == True
-        ):
+        elif (self.initial_full_table_complete == True and min_version_out_of_date == True):
             self.logger.info(
                 "CHANGE_TRACKING_MIN_VALID_VERSION has reported a value greater than current-log-version. Executing a full table sync."
             )
+            self.current_log_version = null
             return True
         else:
             return False

--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -189,7 +189,7 @@ class log_based_sync:
             self.logger.info(
                 "CHANGE_TRACKING_MIN_VALID_VERSION has reported a value greater than current-log-version. Executing a full table sync."
             )
-            self.current_log_version = null
+            self.current_log_version = None 
             return True
         else:
             return False


### PR DESCRIPTION
Error occurring when `self.current_log_version` is `None`
`min_version_out_of_date = min_valid_version > self.current_log_version`

Updated code to factor in None values for current_log_version:
```
        if self.current_log_version is None:
            min_version_out_of_date = False
        else: 
            min_version_out_of_date = min_valid_version > self.current_log_version
```