### PR TITLE
Fix missing table_stream in logical

### DIFF
--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -267,7 +267,8 @@ class log_based_sync:
 
                         desired_columns.append("_sdc_deleted_at")
                         ordered_row.append(None)
-
+                        
+                    table_stream = self.catalog_entry.stream.replace('-', '_')
                     record_message = common.row_to_singer_record(
                         self.catalog_entry,
                         stream_version,


### PR DESCRIPTION
Quick fix to keep the pipelines moving, planning a refactor shortly to exclude `table_stream` from being required anywhere