### PR TITLE
Resolve Malformed Date

### DIFF
--- a/tap_mssql/sync_strategies/logical.py
+++ b/tap_mssql/sync_strategies/logical.py
@@ -261,7 +261,7 @@ class log_based_sync:
                             self.logger.warn(
                                 "Found deleted record with no timestamp, falling back to current time."
                             )
-                            ordered_row.append(time_extracted)
+                            ordered_row.append(str(time_extracted))
                         else:
                             ordered_row.append(row["commit_time"])
 


### PR DESCRIPTION
An issue was discovered in handling deletes with bad timestamps, as an initial move to resolve this it appeared converting to a string returns a valid timestamp